### PR TITLE
Add option to enable hostname verification for redis sink

### DIFF
--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisCommonConfig.java
@@ -44,6 +44,11 @@ public class RedisCommonConfig {
             .withDescription("Use SSL for Redis connection")
             .withDefault(DEFAULT_SSL_ENABLED);
 
+    private static final boolean DEFAULT_HOSTNAME_VERIFICATION = false;
+    private static final Field PROP_SSL_HOSTNAME_VERIFICATION_ENABLED = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "ssl.hostname.verification.enabled")
+            .withDescription("Enable hostname verification")
+            .withDefault(DEFAULT_HOSTNAME_VERIFICATION);
+
     private static final Integer DEFAULT_CONNECTION_TIMEOUT = 2000;
     private static final Field PROP_CONNECTION_TIMEOUT = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "connection.timeout.ms")
             .withDescription("Connection timeout (in ms)")
@@ -95,6 +100,7 @@ public class RedisCommonConfig {
     private String user;
     private String password;
     private boolean sslEnabled;
+    private boolean hostnameVerificationEnabled;
 
     private Integer initialRetryDelay;
     private Integer maxRetryDelay;
@@ -120,8 +126,9 @@ public class RedisCommonConfig {
     }
 
     protected List<Field> getAllConfigurationFields() {
-        return Collect.arrayListOf(PROP_ADDRESS, PROP_DB_INDEX, PROP_USER, PROP_PASSWORD, PROP_SSL_ENABLED, PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT,
-                PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY, PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT, PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY);
+        return Collect.arrayListOf(PROP_ADDRESS, PROP_DB_INDEX, PROP_USER, PROP_PASSWORD, PROP_SSL_ENABLED, PROP_SSL_HOSTNAME_VERIFICATION_ENABLED,
+                PROP_CONNECTION_TIMEOUT, PROP_SOCKET_TIMEOUT, PROP_RETRY_INITIAL_DELAY, PROP_RETRY_MAX_DELAY, PROP_WAIT_ENABLED, PROP_WAIT_TIMEOUT,
+                PROP_WAIT_RETRY_ENABLED, PROP_WAIT_RETRY_DELAY);
     }
 
     protected void init(Configuration config) {
@@ -130,6 +137,7 @@ public class RedisCommonConfig {
         user = config.getString(PROP_USER);
         password = config.getString(PROP_PASSWORD);
         sslEnabled = config.getBoolean(PROP_SSL_ENABLED);
+        hostnameVerificationEnabled = config.getBoolean(PROP_SSL_HOSTNAME_VERIFICATION_ENABLED);
 
         initialRetryDelay = config.getInteger(PROP_RETRY_INITIAL_DELAY);
         maxRetryDelay = config.getInteger(PROP_RETRY_MAX_DELAY);
@@ -166,6 +174,10 @@ public class RedisCommonConfig {
 
     public boolean isSslEnabled() {
         return sslEnabled;
+    }
+
+    public boolean isHostnameVerificationEnabled() {
+        return hostnameVerificationEnabled;
     }
 
     public Integer getInitialRetryDelay() {

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -7,6 +7,8 @@ package io.debezium.storage.redis;
 
 import java.util.regex.Pattern;
 
+import javax.net.ssl.SSLParameters;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +41,7 @@ public class RedisConnection {
     private int connectionTimeout;
     private int socketTimeout;
     private boolean sslEnabled;
+    private boolean hostnameVerificationEnabled;
 
     /**
      *
@@ -49,7 +52,8 @@ public class RedisConnection {
      * @param socketTimeout
      * @param sslEnabled
      */
-    public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled) {
+    public RedisConnection(String address, int dbIndex, String user, String password, int connectionTimeout, int socketTimeout, boolean sslEnabled,
+                           boolean hostnameVerificationEnabled) {
         validateHostPort(address);
 
         this.address = address;
@@ -59,6 +63,7 @@ public class RedisConnection {
         this.connectionTimeout = connectionTimeout;
         this.socketTimeout = socketTimeout;
         this.sslEnabled = sslEnabled;
+        this.hostnameVerificationEnabled = hostnameVerificationEnabled;
     }
 
     /**
@@ -92,6 +97,12 @@ public class RedisConnection {
 
             if (!Strings.isNullOrEmpty(this.password)) {
                 configBuilder = configBuilder.password(this.password);
+            }
+
+            if (hostnameVerificationEnabled) {
+                var sslParameters = new SSLParameters();
+                sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+                configBuilder.sslParameters(sslParameters);
             }
 
             client = new Jedis(address, configBuilder.build());

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/RedisConnection.java
@@ -100,6 +100,7 @@ public class RedisConnection {
             }
 
             if (hostnameVerificationEnabled) {
+                // Enforce strict hostname verification to prevent man-in-the-middle attacks.
                 var sslParameters = new SSLParameters();
                 sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
                 configBuilder.sslParameters(sslParameters);

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/history/RedisSchemaHistory.java
@@ -56,7 +56,7 @@ public class RedisSchemaHistory extends AbstractSchemaHistory {
 
     void connect() {
         RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled());
+                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled());
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_SCHEMA_HISTORY, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }

--- a/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
+++ b/debezium-storage/debezium-storage-redis/src/main/java/io/debezium/storage/redis/offset/RedisOffsetBackingStore.java
@@ -48,7 +48,7 @@ public class RedisOffsetBackingStore extends MemoryOffsetBackingStore {
     void connect() {
         closeClient();
         RedisConnection redisConnection = new RedisConnection(config.getAddress(), config.getDbIndex(), config.getUser(), config.getPassword(),
-                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled());
+                config.getConnectionTimeout(), config.getSocketTimeout(), config.isSslEnabled(), config.isHostnameVerificationEnabled());
         client = redisConnection.getRedisClient(RedisConnection.DEBEZIUM_OFFSETS_CLIENT_NAME, config.isWaitEnabled(), config.getWaitTimeout(),
                 config.isWaitRetryEnabled(), config.getWaitRetryDelay());
     }


### PR DESCRIPTION
Strict hostname verification can now be enabled with a setting in the application.properties:
`debezium.sink.redis.ssl.hostname.verification.enabled=true`

See https://redislabs.atlassian.net/browse/RDSC-3577
